### PR TITLE
Fix install_requires to be a list of strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ setup(name="AmFast",
     test_suite = "tests.suite",
     packages = ['amfast', 'amfast.class_def', 'amfast.remoting'],
     features = {'extensions': extensions},
-    install_requires = {
-        'uuid': 'uuid>=1.3.0'
-    },
+    install_requires = [
+        'uuid>=1.3.0',
+    ],
     classifiers = [
         "Programming Language :: Python :: 2.4",
         "Programming Language :: Python :: 2.5",


### PR DESCRIPTION
I have an environment where I get the following error

```
Processing ./AmFast-0.5.3-r541
    Complete output from command python setup.py egg_info:
    error in AmFast setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-vVXFmV-build/

```

I can't reproduce this in other environments.